### PR TITLE
Remove obsolete/invalid parameters from setPilot to fix #6

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -257,7 +257,7 @@ class Client extends EventEmitter {
     const msg = JSON.stringify({
       method: 'setPilot',
       env: 'pro',
-      params: { mac: getMAC(), src: 'udp', sceneId: 0, c: 0, w: 0, ...state },
+      params: { mac: getMAC(), src: 'udp', ...state },
     });
     this.socket.send(msg, 0, msg.length, 38899, host);
   }


### PR DESCRIPTION
A recent upgrade to the A19 bulbs breaks this plugin.  Some bulbs no longer respond to Homekit control via this plugin. (#6)

My investigation found that the new upgrade made changes to the requirements of the parameters. If the parameters `"sceneId":0,"c":0,"w":0` are sent to the bulb, it returns 'Invalid params' and fails.

By removing these parameters, this plugin works again on A19.

**Reviews are required before merging this PR.**  I don't have other models of the bulb so I do not know if it will break old firmware.  Please provide feedback!