### PR TITLE
Support costco wiz lights that behave differently from philips wiz

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -22,6 +22,10 @@ const discoveryMsgBuf = () => {
   return `{"method":"registration","params":{"phoneMac":"${strMac()}","register":true,"phoneIp":"${strIp()}"}}`;
 };
 
+const getPilotMsgBuf = () => {
+  return `{"method":"getPilot","params":{}}`;
+};
+
 class Client extends EventEmitter {
   constructor({ defaultSendOptions, logLevel, logger } = {}) {
     super();
@@ -108,10 +112,11 @@ class Client extends EventEmitter {
         let sysInfo;
         try {
           response = JSON.parse(decryptedMsg);
-          if (response.method !== 'syncPilot') {
-            return;
+          if (response.params !== undefined) {
+            sysInfo = response.params;
+          } else {
+            sysInfo = response.result;
           }
-          sysInfo = response.params;
           // eslint-disable-next-line no-multi-assign
           sysInfo.deviceId = sysInfo.alias = sysInfo.mac;
         } catch (err) {
@@ -223,13 +228,15 @@ class Client extends EventEmitter {
     const id = sysInfo.deviceId;
     let device;
     if (this.devices.has(id)) {
-      device = this.devices.get(id);
-      device.host = host;
-      device.port = port;
-      device.setSysInfo(sysInfo);
-      device.status = 'online';
-      device.seenOnDiscovery = this.discoveryPacketSequence;
-      this.emit('online', device);
+      if (sysInfo.state !== undefined) {
+        device = this.devices.get(id);
+        device.host = host;
+        device.port = port;
+        device.setSysInfo(sysInfo);
+        device.status = 'online';
+        device.seenOnDiscovery = this.discoveryPacketSequence;
+        this.emit('online', device);
+      }
     } else {
       const deviceOptions = { ...options, client: this, host, port };
       device = this.getDeviceFromSysInfo(sysInfo, deviceOptions);
@@ -287,11 +294,13 @@ class Client extends EventEmitter {
         return;
       }
       const msg = discoveryMsgBuf();
+      const msg2 = getPilotMsgBuf();
       this.socket.send(msg, 0, msg.length, 38899, address);
 
+      // registered devices so obtain state via getPilot
       devices.forEach(d => {
         this.log.debug('client.sendDiscovery() direct device:', d);
-        this.socket.send(msg, 0, msg.length, d.port || 38899, d.host);
+        this.socket.send(msg2, 0, msg2.length, d.port || 38899, d.host);
       });
 
       if (this.discoveryPacketSequence >= Number.MAX_VALUE) {


### PR DESCRIPTION
Recently bought some Costco wiz lights that are not yet hue branded and they appear to behave differently from what this plugin expects. There is no heartbeat "syncPilot" call, a getPilot call is needed to sync up state explicitly. Furthermore, once devices have been registered they will send out getPilot calls instead of the redundant registration discovery request. Note, I don't have any hue branded wiz lights to verify backward compatibility though I reckon it should work. 

For context here are the Costco lights which were purchased: https://www.costco.com/wiz-wi-fi-color-br30-smart-bulb%2C-4-pack.product.100486236.html

Anyway thank you for the plugin! These lights are excellent and at a good price point. 