### PR TITLE
Fix: getter for Name Characteristic returned object instead of the value

### DIFF
--- a/lib/homekit-device/index.js
+++ b/lib/homekit-device/index.js
@@ -19,7 +19,7 @@ class HomeKitDevice {
     this.characteristics = {};
 
     this.addCharacteristic(platform.homebridge.hap.Characteristic.Name, {
-      getValue: async () => {
+      getValue: () => {
         return this.name;
       },
     });


### PR DESCRIPTION
The latest 1.3.0 beta has some additional sanity checking when receiving values from plugins. One of them is if the type of the supplied value matches what the characteristic value expects.

With the latest 1.3.0 beta the following error message appeared (from those said sanity checks), as mentioned in #24 :

```
Name@Homebridge B03F] Unhandled error thrown inside read handler for characteristic: Error: characteristic value expected string and received object
    at Characteristic.validateUserInput (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1917:17)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1428:24
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/util/once.ts:9:18
    at Characteristic.<anonymous> (/usr/local/lib/node_modules/homebridge-wiz-lan/lib/wiz-accessory.js:154:11)
    at Characteristic.emit (events.js:315:20)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1404:14
    at new Promise (<anonymous>)
    at Characteristic.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1402:12)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:140:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:121:57)
```

The problem was that the custom defined `getValue()` defined for the `Characteristic.Name` (as stated in the error message in the first line) didn't actually return the value itself. As it was annotated with async, it returned a `Promise<string>`, which is internally a `object` as stated in the error message.

This should mitigate the issue. And sorry for my false assumptions made in #24. 
The rest of the code seemed okay, besides what I mentioned with the setting of props, but didn't want to go too deep into the project. 