### PR TITLE
Gracefully handle existing accessories from V2

### DIFF
--- a/src/wiz.ts
+++ b/src/wiz.ts
@@ -11,7 +11,6 @@ import { PLATFORM_NAME, PLUGIN_NAME } from "./constants";
 import { Config, Device } from "./types";
 import Accessories from './accessories';
 import { bindSocket, createSocket, registerDiscoveryHandler, sendDiscoveyBroadcast } from "./util/network";
-import { platform } from "os";
 
 export default class HomebridgeWizLan {
   public readonly Service: typeof Service = this.api.hap.Service;

--- a/src/wiz.ts
+++ b/src/wiz.ts
@@ -19,7 +19,7 @@ export default class HomebridgeWizLan {
 
   // this is used to track restored cached accessories
   public readonly accessories: PlatformAccessory[] = [];
-  public readonly initializedAccessories = new Set<PlatformAccessory>();
+  public readonly initializedAccessories = new Set<string>();
   public readonly socket: Socket;
 
   constructor(
@@ -46,7 +46,7 @@ export default class HomebridgeWizLan {
   initAccessory(platformAccessory: PlatformAccessory) {
 
     // Already initialized!!
-    if (this.initializedAccessories.has(platformAccessory)) {
+    if (this.initializedAccessories.has(platformAccessory.UUID)) {
       return;
     }
 
@@ -72,7 +72,7 @@ export default class HomebridgeWizLan {
 
     accessory.init(platformAccessory, device, this);
 
-    this.initializedAccessories.add(platformAccessory);
+    this.initializedAccessories.add(platformAccessory.UUID);
   }
 
   /**


### PR DESCRIPTION
Will first ignore accessories from V2 since they lack the correct context, then reinitialize them later when they are rediscovered. 