### PR TITLE
Add instant response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.2
+- [FIX] Add instant response for bulbs, will now return last-known value if bulbs take more than 1 second to respond.
+
 ## 3.0.1
 - [FEAT] Add a changelog
 - [FEAT] Add batching for getPilot queries which should reduce network traffic a bit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wiz-lan",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wiz-lan",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A homebridge plugin to control Wiz Lights",
   "main": "dist/index.js",
   "keywords": [

--- a/src/accessories/WizBulb/AdaptiveLighting.ts
+++ b/src/accessories/WizBulb/AdaptiveLighting.ts
@@ -38,6 +38,7 @@ export function initAdaptiveLighting(
     // get pilot will disable for us :)
     getPilot(
       wiz,
+      service,
       device,
       () => {},
       () => {}

--- a/src/accessories/WizBulb/characteristics/color.ts
+++ b/src/accessories/WizBulb/characteristics/color.ts
@@ -13,11 +13,15 @@ import { hsvToColor } from "../../../util/color";
 import {
   cachedPilot,
   getPilot,
+  Pilot,
   pilotToColor,
   setPilot,
   updateColorTemp,
 } from "../pilot";
 
+export function transformHue(pilot: Pilot) {
+  return pilotToColor(pilot).hue;
+}
 function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
   const { Characteristic } = wiz;
   service
@@ -25,8 +29,9 @@ function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
     .on("get", (callback) =>
       getPilot(
         wiz,
+        service,
         device,
-        (pilot) => callback(null, pilotToColor(pilot).hue),
+        (pilot) => callback(null, transformHue(pilot)),
         callback
       )
     )
@@ -50,6 +55,9 @@ function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
     );
 }
 
+export function transformSaturation(pilot: Pilot) {
+  return pilotToColor(pilot).saturation;
+}
 function initSaturation(
   service: WizService,
   device: Device,
@@ -61,8 +69,9 @@ function initSaturation(
     .on("get", (callback) =>
       getPilot(
         wiz,
+        service,
         device,
-        (pilot) => callback(null, pilotToColor(pilot).saturation),
+        (pilot) => callback(null, transformSaturation(pilot)),
         callback
       )
     )

--- a/src/accessories/WizBulb/characteristics/dimming.ts
+++ b/src/accessories/WizBulb/characteristics/dimming.ts
@@ -9,8 +9,11 @@ import {
   getPilot as _getPilot,
   setPilot as _setPilot,
 } from "../../../util/network";
-import { getPilot, setPilot } from "../pilot";
+import { getPilot, Pilot, setPilot } from "../pilot";
 
+export function transformDimming(pilot: Pilot) {
+  return Number(pilot.dimming);
+}
 export function initDimming(
   service: WizService,
   device: Device,
@@ -22,8 +25,9 @@ export function initDimming(
     .on("get", (callback) =>
       getPilot(
         wiz,
+        service,
         device,
-        (pilot) => callback(null, Number(pilot.dimming)),
+        (pilot) => callback(null, transformDimming(pilot)),
         callback
       )
     )

--- a/src/accessories/WizBulb/characteristics/onOff.ts
+++ b/src/accessories/WizBulb/characteristics/onOff.ts
@@ -9,8 +9,11 @@ import {
   getPilot as _getPilot,
   setPilot as _setPilot,
 } from "../../../util/network";
-import { getPilot, setPilot } from "../pilot";
+import { getPilot, Pilot, setPilot } from "../pilot";
 
+export function transformOnOff(pilot: Pilot) {
+  return Number(pilot.state);
+}
 export function initOnOff(
   service: WizService,
   device: Device,
@@ -22,8 +25,9 @@ export function initOnOff(
     .on("get", (callback) =>
       getPilot(
         wiz,
+        service,
         device,
-        (pilot) => callback(null, Number(pilot.state)),
+        (pilot) => callback(null, transformOnOff(pilot)),
         callback
       )
     )

--- a/src/accessories/WizBulb/characteristics/temperature.ts
+++ b/src/accessories/WizBulb/characteristics/temperature.ts
@@ -11,8 +11,11 @@ import {
   setPilot as _setPilot,
 } from "../../../util/network";
 import { kelvinToMired, miredToKelvin } from "../../../util/color";
-import { getPilot, pilotToColor, setPilot, updateColorTemp } from "../pilot";
+import { getPilot, Pilot, pilotToColor, setPilot, updateColorTemp } from "../pilot";
 
+export function transformTemperature(pilot: Pilot) {
+  return kelvinToMired(pilotToColor(pilot).temp);
+}
 export function initTemperature(
   service: WizService,
   device: Device,
@@ -24,8 +27,9 @@ export function initTemperature(
     .on("get", (callback) =>
       getPilot(
         wiz,
+        service,
         device,
-        (pilot) => callback(null, kelvinToMired(pilotToColor(pilot).temp)),
+        (pilot) => callback(null, transformTemperature(pilot)),
         callback
       )
     )


### PR DESCRIPTION
Will respond with cached values for bulbs that take longer than 1s. 

Unfortunately for offline bulbs,
> The HomeKit API for events does not support the setting of a not responding status. 
https://github.com/homebridge/HAP-NodeJS/pull/556#issuecomment-486333661

This means that non-responding bulbs will not show as not-responding until the next pull from homekit, most likely the next time you open the app. 