### PR TITLE
transform the received dimming value to also fit the 10 to 100 range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wiz-lan",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A homebridge plugin to control Wiz Lights",
   "main": "dist/index.js",
   "keywords": [

--- a/src/accessories/WizBulb/characteristics/dimming.ts
+++ b/src/accessories/WizBulb/characteristics/dimming.ts
@@ -12,7 +12,7 @@ import {
 import { getPilot, Pilot, setPilot } from "../pilot";
 
 export function transformDimming(pilot: Pilot) {
-  return Number(pilot.dimming);
+  return Number(Math.round((Math.max(10, Number(pilot.dimming)) - 100) * 1.1 + 100));
 }
 export function initDimming(
   service: WizService,

--- a/src/accessories/WizBulb/pilot.ts
+++ b/src/accessories/WizBulb/pilot.ts
@@ -136,6 +136,9 @@ export function setPilot(
   callback: (error: Error | null) => void
 ) {
   const oldPilot = cachedPilot[device.mac];
+  if (typeof oldPilot == "undefined") {
+    return;
+  }
   const oldPilotValues = {
     state: oldPilot.state ?? false,
     dimming: oldPilot.dimming ?? 10,


### PR DESCRIPTION
Hello,
this pull request should hopefully fix issue #51.

While testing I found out, that setting the brightness to 1% resulted in the value jumping to 10% in some cases (when reading the value back from the bulb).

So I looked at the code and found the special handling of fitting the range to 10..100 while setting the brightness. While reading this was not "reversed" so I added that. This seems consistent with the Wiz App.

Please consider merging this request as this should fix some value inconsistencies in the Home App.

Best,
Manuel