### PR TITLE
feat: Support durable custom names in config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface Config extends PlatformConfig {
   port?: number;
   broadcast?: string;
   address?: string;
-  devices?: { host: string }[];
+  devices?: { host?: string, mac?: string, name?: string }[];
 }
 export interface Device {
   model: string;

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -219,7 +219,7 @@ export function registerDiscoveryHandler(
   }
 }
 
-export function sendDiscoveyBroadcast(service: HomebridgeWizLan) {
+export function sendDiscoveryBroadcast(service: HomebridgeWizLan) {
   const { ADDRESS, MAC, BROADCAST } = getNetworkConfig(service);
 
   const log = makeLogger(service, "Discovery");
@@ -235,11 +235,13 @@ export function sendDiscoveyBroadcast(service: HomebridgeWizLan) {
   // Send discovery message to listed devices
   if (Array.isArray(service.config.devices)) {
     for (const device of service.config.devices) {
-      service.socket.send(
-        `{"method":"registration","params":{"phoneMac":"${MAC}","register":false,"phoneIp":"${ADDRESS}"}}`,
-        BROADCAST_PORT,
-        device.host
-      );
+      if (device.host) {
+        service.socket.send(
+          `{"method":"registration","params":{"phoneMac":"${MAC}","register":false,"phoneIp":"${ADDRESS}"}}`,
+          BROADCAST_PORT,
+          device.host
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Works just fine for new accessories.  For old ones (i.e., in cache), initialization and naming happen at cache-load, so the configured name doesn't apply.  Addressing that minor issue is left as an exercise for the reader.

Closes #18 
