### PR TITLE
feat: implement dynamic scenes selector

### DIFF
--- a/src/accessories/WizBulb/AdaptiveLighting.ts
+++ b/src/accessories/WizBulb/AdaptiveLighting.ts
@@ -38,7 +38,7 @@ export function initAdaptiveLighting(
     // get pilot will disable for us :)
     getPilot(
       wiz,
-      service,
+      accessory,
       device,
       () => {},
       () => {}

--- a/src/accessories/WizBulb/characteristics/color.ts
+++ b/src/accessories/WizBulb/characteristics/color.ts
@@ -1,7 +1,7 @@
 import {
   CharacteristicSetCallback,
   CharacteristicValue,
-  Service as WizService,
+  PlatformAccessory,
 } from "homebridge";
 import HomebridgeWizLan from "../../../wiz";
 import { Device } from "../../../types";
@@ -22,16 +22,22 @@ import {
 export function transformHue(pilot: Pilot) {
   return pilotToColor(pilot).hue;
 }
-function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
-  const { Characteristic } = wiz;
+function initHue(
+  accessory: PlatformAccessory,
+  device: Device,
+  wiz: HomebridgeWizLan
+) {
+  const { Characteristic, Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
+  const scenesService = new Service.Television("Scenes");
   service
     .getCharacteristic(Characteristic.Hue)
-    .on("get", (callback) =>
+    .on("get", callback =>
       getPilot(
         wiz,
-        service,
+        accessory,
         device,
-        (pilot) => callback(null, transformHue(pilot)),
+        pilot => callback(null, transformHue(pilot)),
         callback
       )
     )
@@ -40,6 +46,7 @@ function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
       (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
         setPilot(
           wiz,
+          accessory,
           device,
           {
             temp: undefined,
@@ -49,7 +56,7 @@ function initHue(service: WizService, device: Device, wiz: HomebridgeWizLan) {
               wiz
             ),
           },
-          updateColorTemp(device, service, wiz, next)
+          updateColorTemp(device, accessory, wiz, next)
         );
       }
     );
@@ -59,19 +66,20 @@ export function transformSaturation(pilot: Pilot) {
   return pilotToColor(pilot).saturation;
 }
 function initSaturation(
-  service: WizService,
+  accessory: PlatformAccessory,
   device: Device,
   wiz: HomebridgeWizLan
 ) {
-  const { Characteristic } = wiz;
+  const { Characteristic, Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   service
     .getCharacteristic(Characteristic.Saturation)
     .on("get", (callback) =>
       getPilot(
         wiz,
-        service,
+        accessory,
         device,
-        (pilot) => callback(null, transformSaturation(pilot)),
+        pilot => callback(null, transformSaturation(pilot)),
         callback
       )
     )
@@ -80,6 +88,7 @@ function initSaturation(
       (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
         setPilot(
           wiz,
+          accessory,
           device,
           {
             temp: undefined,
@@ -89,17 +98,17 @@ function initSaturation(
               wiz
             ),
           },
-          updateColorTemp(device, service, wiz, next)
+          updateColorTemp(device, accessory, wiz, next)
         );
       }
     );
 }
 
 export function initColor(
-  service: WizService,
+  accessory: PlatformAccessory,
   device: Device,
   wiz: HomebridgeWizLan
 ) {
-  initHue(service, device, wiz);
-  initSaturation(service, device, wiz);
+  initHue(accessory, device, wiz);
+  initSaturation(accessory, device, wiz);
 }

--- a/src/accessories/WizBulb/characteristics/dimming.ts
+++ b/src/accessories/WizBulb/characteristics/dimming.ts
@@ -1,6 +1,7 @@
 import {
   CharacteristicSetCallback,
   CharacteristicValue,
+  PlatformAccessory,
   Service as WizService,
 } from "homebridge";
 import HomebridgeWizLan from "../../../wiz";
@@ -15,17 +16,18 @@ export function transformDimming(pilot: Pilot) {
   return Number(Math.round((Math.max(10, Number(pilot.dimming)) - 100) * 1.1 + 100));
 }
 export function initDimming(
-  service: WizService,
+  accessory: PlatformAccessory,
   device: Device,
   wiz: HomebridgeWizLan
 ) {
-  const { Characteristic } = wiz;
+  const { Characteristic, Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   service
     .getCharacteristic(Characteristic.Brightness)
     .on("get", (callback) =>
       getPilot(
         wiz,
-        service,
+        accessory,
         device,
         (pilot) => callback(null, transformDimming(pilot)),
         callback
@@ -36,6 +38,7 @@ export function initDimming(
       (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
         setPilot(
           wiz,
+          accessory,
           device,
           // for some reason < 10% is invalid, so we gotta fit it into 10% <-> 100%
           { dimming: Math.round((Math.max(1, Number(newValue)) + 10) / 1.1) },

--- a/src/accessories/WizBulb/characteristics/onOff.ts
+++ b/src/accessories/WizBulb/characteristics/onOff.ts
@@ -1,6 +1,7 @@
 import {
   CharacteristicSetCallback,
   CharacteristicValue,
+  PlatformAccessory,
   Service as WizService,
 } from "homebridge";
 import HomebridgeWizLan from "../../../wiz";
@@ -15,26 +16,27 @@ export function transformOnOff(pilot: Pilot) {
   return Number(pilot.state);
 }
 export function initOnOff(
-  service: WizService,
+  accessory: PlatformAccessory,
   device: Device,
   wiz: HomebridgeWizLan
 ) {
-  const { Characteristic } = wiz;
+  const { Characteristic, Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   service
     .getCharacteristic(Characteristic.On)
-    .on("get", (callback) =>
+    .on("get", callback =>
       getPilot(
         wiz,
-        service,
+        accessory,
         device,
-        (pilot) => callback(null, transformOnOff(pilot)),
+        pilot => callback(null, transformOnOff(pilot)),
         callback
       )
     )
     .on(
       "set",
       (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
-        setPilot(wiz, device, { state: Boolean(newValue) }, next);
+        setPilot(wiz, accessory, device, { state: Boolean(newValue) }, next);
       }
     );
 }

--- a/src/accessories/WizBulb/characteristics/scenes.ts
+++ b/src/accessories/WizBulb/characteristics/scenes.ts
@@ -1,0 +1,172 @@
+import {
+  CharacteristicSetCallback,
+  CharacteristicValue,
+  PlatformAccessory,
+  Service as WizService,
+} from "homebridge";
+import HomebridgeWizLan from "../../../wiz";
+import { Device } from "../../../types";
+import {
+  getPilot as _getPilot,
+  setPilot as _setPilot,
+} from "../../../util/network";
+import { getPilot, setPilot } from "../pilot";
+import { Pilot } from "../pilot";
+import { isRGB, isTW, turnOffIfNeeded } from "../util";
+
+enum SCENES {
+  "Ocean" = 1,
+  "Romance",
+  "Sunset",
+  "Party",
+  "Fireplace",
+  "Cozy",
+  "Forest",
+  "Pastel Colors",
+  "Wake up",
+  "Bedtime",
+  "Warm White",
+  "Daylight",
+  "Cool white",
+  "Night light",
+  "Focus",
+  "Relax",
+  "True colors",
+  "TV time",
+  "Plantgrowth",
+  "Spring",
+  "Summer",
+  "Fall",
+  "Deepdive",
+  "Jungle",
+  "Mojito",
+  "Club",
+  "Christmas",
+  "Halloween",
+  "Candlelight",
+  "Golden white",
+  "Pulse",
+  "Steampunk",
+}
+
+const DW_BULBS_SUPPORTED_SCENES_IDS = [9, 10, 13, 14, 29, 30, 31, 32];
+const TW_BULBS_SUPPORTED_SCENES_IDS = [
+  6, 9, 10, 11, 12, 13, 14, 15, 16, 18, 29, 30, 31, 32,
+];
+const RGB_BULBS_SUPPORTED_SCENES_IDS = Object.keys(SCENES).reduce(
+  (ids, key) => (isNaN(Number(key)) ? ids : [...ids, Number(key)]),
+  [] as number[]
+);
+
+/** 
+* Returns supported scenes for device. Based on https://bit.ly/3hLImPa.
+* @param device
+* @return array of ids of scenes supported by the particular light type
+*/
+function supportedScenesIdsForDevice(device: Device) {
+  if (isTW(device)) return TW_BULBS_SUPPORTED_SCENES_IDS;
+  else if (isRGB(device)) return RGB_BULBS_SUPPORTED_SCENES_IDS;
+  return DW_BULBS_SUPPORTED_SCENES_IDS;
+}
+
+export function transformEffectId(pilot: Pilot): number {
+  return Number(pilot.sceneId);
+}
+
+export function transformEffectActive(pilot: Pilot): boolean {
+  return Number(pilot.sceneId) > 0;
+}
+
+export function initScenes(
+  wiz: HomebridgeWizLan,
+  accessory: PlatformAccessory,
+  device: Device
+) {
+  const { Characteristic, Service } = wiz;
+
+  let scenesService = accessory.getService(Service.Television);
+  const service = accessory.getService(Service.Lightbulb)!;
+  if (!scenesService) {
+    scenesService = new Service.Television("Scenes");
+    accessory.addService(scenesService);
+
+    scenesService
+      .getCharacteristic(Characteristic.ActiveIdentifier)
+      .on("get", callback =>
+        getPilot(
+          wiz,
+          accessory,
+          device,
+          pilot => callback(null, transformEffectId(pilot)),
+          callback
+        )
+      )
+      .on(
+        "set",
+        (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
+          const sceneId = Number(newValue);
+          setPilot(wiz, accessory, device, { sceneId }, next);
+          if (sceneId !== 0) device.lastSelectedSceneId = sceneId;
+        }
+      );
+
+    scenesService
+      .getCharacteristic(Characteristic.Active)
+      .on("get", callback =>
+        getPilot(
+          wiz,
+          accessory,
+          device,
+          pilot => callback(null, transformEffectActive(pilot)),
+          callback
+        )
+      )
+      .on(
+        "set",
+        (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
+          console.log("active: ", newValue);
+          if (newValue === 0) {
+            scenesService!.setCharacteristic(
+              Characteristic.ActiveIdentifier,
+              0
+            );
+
+            next(null);
+          } else {
+            scenesService!.setCharacteristic(
+              Characteristic.ActiveIdentifier,
+              device.lastSelectedSceneId ?? 1
+            );
+            turnOffIfNeeded(Characteristic.Hue, service);
+            turnOffIfNeeded(Characteristic.Saturation, service);
+
+            next(null);
+          }
+        }
+      );
+
+    const scenesIds = supportedScenesIdsForDevice(device);
+
+    scenesIds.forEach((sceneId: number) => {
+      const sceneName = SCENES[sceneId];
+      console.log(sceneName);
+      const effectInputSource = accessory.addService(
+        Service.InputSource,
+        sceneId,
+        sceneName
+      );
+      effectInputSource
+        .setCharacteristic(Characteristic.Identifier, sceneId)
+        .setCharacteristic(Characteristic.ConfiguredName, sceneName)
+        .setCharacteristic(
+          Characteristic.IsConfigured,
+          Characteristic.IsConfigured.CONFIGURED
+        )
+        .setCharacteristic(
+          Characteristic.InputSourceType,
+          Characteristic.InputSourceType.HDMI
+        );
+      scenesService!.addLinkedService(effectInputSource);
+    });
+  }
+}

--- a/src/accessories/WizBulb/characteristics/temperature.ts
+++ b/src/accessories/WizBulb/characteristics/temperature.ts
@@ -17,17 +17,18 @@ export function transformTemperature(pilot: Pilot) {
   return kelvinToMired(pilotToColor(pilot).temp);
 }
 export function initTemperature(
-  service: WizService,
+  accessory: PlatformAccessory,
   device: Device,
   wiz: HomebridgeWizLan
 ) {
-  const { Characteristic } = wiz;
+  const { Characteristic, Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   service
     .getCharacteristic(Characteristic.ColorTemperature)
     .on("get", (callback) =>
       getPilot(
         wiz,
-        service,
+        accessory,
         device,
         (pilot) => callback(null, transformTemperature(pilot)),
         callback
@@ -38,6 +39,7 @@ export function initTemperature(
       (newValue: CharacteristicValue, next: CharacteristicSetCallback) => {
         setPilot(
           wiz,
+          accessory,
           device,
           {
             temp: miredToKelvin(Number(newValue)),
@@ -45,7 +47,7 @@ export function initTemperature(
             g: undefined,
             b: undefined,
           },
-          updateColorTemp(device, service, wiz, next)
+          updateColorTemp(device, accessory, wiz, next)
         );
       }
     );

--- a/src/accessories/WizBulb/index.ts
+++ b/src/accessories/WizBulb/index.ts
@@ -43,12 +43,12 @@ const WizBulb: WizAccessory = {
     }
 
     // All bulbs support on/off + dimming
-    initOnOff(service, device, wiz);
-    initDimming(service, device, wiz);
+    initOnOff(accessory, device, wiz);
+    initDimming(accessory, device, wiz);
 
     // Those with these SHRGB/SHTW have color temp
     if (isRGB(device) || isTW(device)) {
-      initTemperature(service, device, wiz);
+      initTemperature(accessory, device, wiz);
       initAdaptiveLighting(wiz, service, accessory, device);
     } else {
       const charcteristic = service.getCharacteristic(
@@ -61,7 +61,7 @@ const WizBulb: WizAccessory = {
 
     // Those with SHRGB have RGB color!
     if (isRGB(device)) {
-      initColor(service, device, wiz);
+      initColor(accessory, device, wiz);
     } else {
       const hue = service.getCharacteristic(Characteristic.Hue);
       if (typeof hue !== "undefined") {

--- a/src/accessories/WizBulb/index.ts
+++ b/src/accessories/WizBulb/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./characteristics";
 import { initAdaptiveLighting } from "./AdaptiveLighting";
 import { isRGB, isTW } from "./util";
+import { initScenes } from "./characteristics/scenes";
 
 const WizBulb: WizAccessory = {
   is: (device: Device) =>
@@ -72,6 +73,8 @@ const WizBulb: WizAccessory = {
         service.removeCharacteristic(saturation);
       }
     }
+
+    initScenes(wiz, accessory, device);
   },
 };
 

--- a/src/accessories/WizBulb/pilot.ts
+++ b/src/accessories/WizBulb/pilot.ts
@@ -191,7 +191,7 @@ export function updateColorTemp(
   const { Service } = wiz;
   const service = accessory.getService(Service.Lightbulb)!;
   return (error: Error | null) => {
-    if (isTW(device)) {
+    if (isTW(device) || isRGB(device)) {
       if (error === null) {
         const color = pilotToColor(cachedPilot[device.mac]);
         service

--- a/src/accessories/WizBulb/pilot.ts
+++ b/src/accessories/WizBulb/pilot.ts
@@ -1,4 +1,4 @@
-import { Characteristic, Service, Service as WizService } from "homebridge";
+import { PlatformAccessory, Service, Service as WizService } from "homebridge";
 
 import HomebridgeWizLan from "../../wiz";
 import { Device } from "../../types";
@@ -48,10 +48,13 @@ export const disabledAdaptiveLightingCallback: {
 
 function updatePilot(
   wiz: HomebridgeWizLan,
-  service: Service,
+  accessory: PlatformAccessory,
   device: Device,
   pilot: Pilot | Error
 ) {
+  const { Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
+
   service
     .getCharacteristic(wiz.Characteristic.On)
     .updateValue(pilot instanceof Error ? pilot : transformOnOff(pilot));
@@ -79,11 +82,13 @@ function updatePilot(
 // caching into account
 export function getPilot(
   wiz: HomebridgeWizLan,
-  service: Service,
+  accessory: PlatformAccessory,
   device: Device,
   onSuccess: (pilot: Pilot) => void,
   onError: (error: Error) => void
 ) {
+  const { Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   let callbacked = false;
   const onDone = (error: Error | null, pilot: Pilot) => {
     const shouldCallback = !callbacked;
@@ -113,7 +118,7 @@ export function getPilot(
     if (shouldCallback) {
       onSuccess(pilot);
     } else {
-      updatePilot(wiz, service, device, pilot);
+      updatePilot(wiz, accessory, device, pilot);
     }
   };
   const timeout = setTimeout(() => {
@@ -131,6 +136,7 @@ export function getPilot(
 
 export function setPilot(
   wiz: HomebridgeWizLan,
+  accessory: PlatformAccessory,
   device: Device,
   pilot: Partial<Pilot>,
   callback: (error: Error | null) => void
@@ -178,10 +184,12 @@ export function pilotToColor(pilot: Pilot) {
 // Need to update hue, saturation, and temp when ANY of these change
 export function updateColorTemp(
   device: Device,
-  service: WizService,
+  accessory: PlatformAccessory,
   wiz: HomebridgeWizLan,
   next: (error: Error | null) => void
 ) {
+  const { Service } = wiz;
+  const service = accessory.getService(Service.Lightbulb)!;
   return (error: Error | null) => {
     if (isTW(device)) {
       if (error === null) {

--- a/src/accessories/WizBulb/util.ts
+++ b/src/accessories/WizBulb/util.ts
@@ -1,8 +1,22 @@
 import { Device } from "../../types";
+import { Characteristic, Service, WithUUID } from "homebridge";
 
 export function isRGB(device: Device) {
   return device.model.includes("SHRGB");
 }
 export function isTW(device: Device) {
   return device.model.includes("SHTW");
+}
+
+export function turnOffIfNeeded(
+  characteristic: WithUUID<{
+    new (): Characteristic;
+  }>,
+  service: Service,
+  useSetValue = false
+) {
+  const ch = service.getCharacteristic(characteristic);
+  if (ch?.value !== 0) {
+    useSetValue ? ch.setValue(0) : ch.updateValue(0);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,12 @@ export interface Config extends PlatformConfig {
   port?: number;
   broadcast?: string;
   address?: string;
-  devices?: { host?: string, mac?: string, name?: string }[];
+  devices?: { host?: string; mac?: string; name?: string }[];
 }
 export interface Device {
   model: string;
   ip: string;
   mac: string;
+
+  lastSelectedSceneId?: number;
 }


### PR DESCRIPTION
Hi, 
I'm working on a implementation of dynamic scenes selector in Home app. So here is the first somehow usable version 🙂. I have tested it only on RGB bulb type so it would be fine if someone could test it with other types as well. Also I would appreaciate any sort of code review! 

As the control for selecting the scene you want is used Television input selector added as service to the parent PlatformAccessory of the device so it get nicely listed under other light's control 🙂. The idea is taken from this article https://sprut.ai/client/article/2760 as well as this implementation in homebridge plugin https://bit.ly/3kju9Lc so thanks them!

Also I would like to say thanks for this project as well!

Solves #65 

<img width="516" alt="image" src="https://user-images.githubusercontent.com/250009/133916885-1a50b897-198f-410a-a91d-e49fc8dfb6e1.png">
