### PR TITLE
Fix dimming math + NaN dimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.2.1
+- [FIX] Fixes the dimming math to correctly map 0% -> 10% 
+- [FIX] Handles bulb not sending a brightness value, defaults to the on/off state of the bulb
+- Thank you [@MoTechnicalities](https://github.com/motechnicalities) for diagnosing and responding to these issues
+
 ## 3.2.0
 - [FEAT] Support for Wiz Plugs/Outlets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-wiz-lan",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-wiz-lan",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "getmac": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wiz-lan",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A homebridge plugin to control Wiz Lights",
   "main": "dist/index.js",
   "keywords": [

--- a/src/accessories/WizBulb/characteristics/dimming.ts
+++ b/src/accessories/WizBulb/characteristics/dimming.ts
@@ -13,7 +13,9 @@ import {
 import { getPilot, Pilot, setPilot } from "../pilot";
 
 export function transformDimming(pilot: Pilot) {
-  return Number(Math.round((Math.max(10, Number(pilot.dimming)) - 100) * 1.1 + 100));
+  // do the reverse of the below
+  // 10% <-> 100% --> 1% <-> 100% 
+  return Math.floor(Number(pilot.dimming) * 1.1) - 10;
 }
 export function initDimming(
   accessory: PlatformAccessory,
@@ -40,8 +42,9 @@ export function initDimming(
           wiz,
           accessory,
           device,
-          // for some reason < 10% is invalid, so we gotta fit it into 10% <-> 100%
-          { dimming: Math.round((Math.max(1, Number(newValue)) + 10) / 1.1) },
+          // for some reason < 10% is invalid, so we gotta fit 0% <-> 100% it into 10% <-> 100%
+          // 0%, 1% -> 10% since that's the minimum acceptable value
+          { dimming: Math.floor(Number(newValue) * 0.9) + 10 },
           next
         );
       }

--- a/src/accessories/WizBulb/pilot.ts
+++ b/src/accessories/WizBulb/pilot.ts
@@ -33,7 +33,7 @@ export interface Pilot {
   sceneId?: number;
   speed?: number;
   temp?: number;
-  dimming: number;
+  dimming?: number;
   r?: number;
   g?: number;
   b?: number;
@@ -137,7 +137,11 @@ export function getPilot(
     ) {
       disabledAdaptiveLightingCallback[device.mac]?.();
     }
-    cachedPilot[device.mac] = pilot;
+    cachedPilot[device.mac] = {
+      // if no dimming info provided, use the last known on/off state
+      dimming: (pilot.state ?? old.state) ? 100 : 10,
+      ...pilot
+    };
     if (shouldCallback) {
       onSuccess(pilot);
     } else {

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -236,6 +236,7 @@ export function sendDiscoveryBroadcast(service: HomebridgeWizLan) {
   if (Array.isArray(service.config.devices)) {
     for (const device of service.config.devices) {
       if (device.host) {
+        log.info(`Sending discovery UDP broadcast to ${device.host}:${BROADCAST_PORT}`);
         service.socket.send(
           `{"method":"registration","params":{"phoneMac":"${MAC}","register":false,"phoneIp":"${ADDRESS}"}}`,
           BROADCAST_PORT,


### PR DESCRIPTION
1. Fixes the dimming math to correctly map 0% -> 10% (#92)
2. Fixes bulb not sending a brightness value, defaults to the on/off state of the bulb (#96, #84)