### PR TITLE
Added support for Wiz Smart Plug ESP25_SOCKET_01

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Based off of kpsuperplane/homebridge-iotas
 
 ## Currently supports
 - Lightbulbs (RGB, Color Temp, and Single Color) (tested with Wiz 100W Color & Wiz 30W Filaments)
-- Wiz Plugs/Outlets (ESP10_SOCKET_06)
+- Wiz Plugs/Outlets (ESP10_SOCKET_06, ESP25_SOCKET_01)
 
 # Installation
 

--- a/src/accessories/WizSocket/index.ts
+++ b/src/accessories/WizSocket/index.ts
@@ -12,7 +12,7 @@ import {
 
 const WizSocket: WizAccessory = {
   is: (device: Device) =>
-    ["ESP10_SOCKET_06"].some((id) => device.model.includes(id)),
+    ["ESP10_SOCKET_06", "ESP25_SOCKET_01"].some((id) => device.model.includes(id)),
   getName: (_: Device) => {
     return "Wiz Socket";
   },


### PR DESCRIPTION
Added support for Wiz Smart Plug model [B127410](https://www.wizconnected.com/fi-fi/p/laitteet-alykas-pistoke/8719514552685). Model currently sold in Finland and propably in other Scandinavian countries.