### PR TITLE
Add lastStatus setting so lights remember their setting when turned on

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Luckily, even if we only enable the color mode, we still get a nice temperature 
 ### Last Status (config setting)
 If a "rhythm" is selected in the Wiz app and `lastStatus` is set to `true`, the lights will always turn on to the rhythm. When rhythms are disabled, lights turn on to whatever setting they had when last turned off.
 
-For some reason when the lights are turned off while on the "Night light" setting, the lights turn back on to whatever setting they were on before being switched to "Night light". This is the only known light setting that causes `lastStatus` to not work correctly.
-
 # Development
 Ideas from http://blog.dammitly.net/2019/10/cheap-hackable-wifi-light-bulbs-or-iot.html?m=1
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Full configuration options:
     // Default: false
     "enableScenes": false,
 
+    // [Optional] Lights turn on with the same settings they had when turned off (light configs in HomeKit are ignored).
+    // Default: false
+    "lastStatus": false,
+
     // [Optional] UDP Broadcast address for bulb discovery
     // Default: 255.255.255.255
     "broadcast": "255.255.255.255",
@@ -67,6 +71,11 @@ The Wiz bulbs strongly distinguish between RGB color modes and Kelvin color mode
 Luckily, even if we only enable the color mode, we still get a nice temperature picker. Problem is, the color temperature is given in standard HSV. As such, this app will try to guess which one to best use given a color, and you will notice some significant brightness variance switching between a "temp" hue and a "color" hue.
 
 **In particular, since the Wiz bulbs only support up to 6500K, this means that only the top-ish half of the temperature picker is actually bright**
+
+### Last Status (config setting)
+If a "rhythm" is selected in the Wiz app and `lastStatus` is set to `true`, the lights will always turn on to the rhythm. When rhythms are disabled, lights turn on to whatever setting they had when last turned off.
+
+For some reason when the lights are turned off while on the "Night light" setting, the lights turn back on to whatever setting they were on before being switched to "Night light". This is the only known light setting that causes `lastStatus` to not work correctly.
 
 # Development
 Ideas from http://blog.dammitly.net/2019/10/cheap-hackable-wifi-light-bulbs-or-iot.html?m=1

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,12 @@
         "description": "[Optional] Turn on support for scenes with your lightbulbs. THIS WILL MAKE IT IMPOSSIBLE TO GROUP LIGHTS",
         "default": false
       },
+      "lastStatus": {
+        "title": "Last Status",
+        "type": "boolean",
+        "description": "[Optional] Lights will remember the last mode used when turned on (light settings in HomeKit will be ignored).",
+        "default": false
+      },
       "broadcast": {
         "title": "Broadcast Address",
         "type": "string",

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { PlatformConfig } from "homebridge";
 export interface Config extends PlatformConfig {
   port?: number;
   enableScenes?: boolean;
+  lastStatus?: boolean;
   broadcast?: string;
   address?: string;
   devices?: { host?: string; mac?: string; name?: string }[];


### PR DESCRIPTION
Add a `lastStatus` setting so lights turn back on to whatever setting they had when turned off.

For some reason when the lights are turned off while on the "Night light" setting, the lights turn back on to whatever setting they were on before being switched to "Night light". This is the only known light setting that causes `lastStatus` to not work correctly. There is an error message in the Homebridge Logs that seems like it might be the cause. I opened this issue for it https://github.com/kpsuperplane/homebridge-wiz-lan/issues/120

Love this plugin! Was gifted some wiz lights and needed the homekit integration this enables for full automation. This has been working great!