### PR TITLE
Change log level of pings to debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chanconrad/homebridge-wiz-lan",
+  "name": "homebridge-wiz-lan",
   "version": "3.2.8",
   "description": "A homebridge plugin to control Wiz Lights",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-wiz-lan",
+  "name": "@chanconrad/homebridge-wiz-lan",
   "version": "3.2.8",
   "description": "A homebridge plugin to control Wiz Lights",
   "main": "dist/index.js",

--- a/src/wiz.ts
+++ b/src/wiz.ts
@@ -88,7 +88,7 @@ export default class HomebridgeWizLan {
       this.log.info(`[Refresh] Setting up ping for every ${interval} seconds`);
       setInterval(() => {
         const accessories = Object.values(this.initializedAccessories);
-        this.log.info(`[Refresh] Pinging ${accessories.length} accessories...`);
+        this.log.debug(`[Refresh] Pinging ${accessories.length} accessories...`);
         for (const accessory of accessories) {
           accessory.getPilot().catch((error) => this.log.error(error));
         }


### PR DESCRIPTION
#128 implements periodic pings, but outputs an info-level log which is excessive and clutters the logs.

As suggested by https://github.com/kpsuperplane/homebridge-wiz-lan/pull/128#issuecomment-1381898222 and https://github.com/kpsuperplane/homebridge-wiz-lan/issues/127#issuecomment-1382258065, these log messages should be for debugging only.

This PR changes the log level to debug.