### PR TITLE
Fix HomeKit lag: setPilot ack timeout, getPilot retransmit, cache-first reads

### DIFF
--- a/src/accessories/WizLight/pilot.ts
+++ b/src/accessories/WizLight/pilot.ts
@@ -1,7 +1,7 @@
 import { PlatformAccessory } from "homebridge";
 
 import HomebridgeWizLan from "../../wiz";
-import { isOffline, recordFailure, recordSuccess } from "../../util/offline";
+import { isOffline, recordFailureOnce, recordSuccess } from "../../util/offline";
 import { Device } from "../../types";
 import {
   getPilot as _getPilot,
@@ -113,36 +113,43 @@ export function getPilot(
   onError: (error: Error) => void
 ) {
   const deviceIsOffline = isOffline(device.mac);
+  // Once HomeKit has been answered, the probe below only refreshes
+  // characteristics via updatePilot — the callbacks must not fire twice.
+  let responded = false;
 
   if (deviceIsOffline) {
     // Respond immediately so HomeKit doesn't wait for the UDP timeout
     onError(new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
+    responded = true;
     // Fall through to still probe the device so recovery is detected
+  } else if (typeof cachedPilot[device.mac] !== "undefined") {
+    // Answer from cache right away instead of holding HomeKit ("Updating...")
+    // through a live UDP round trip; the probe pushes fresh state when it lands
+    onSuccess(cachedPilot[device.mac]);
+    responded = true;
   }
 
   _getPilot<Pilot>(wiz, device, (error, pilot) => {
     if (error !== null) {
       const threshold = Math.max(1, Number(wiz.config.pingFailuresBeforeOffline ?? 3));
-      const newlyOffline = recordFailure(device.mac, threshold);
+      const newlyOffline = recordFailureOnce(error, device.mac, threshold);
       if (newlyOffline) {
         wiz.log.warn(`[${device.mac}] Device is now offline (${threshold} missed pings)`);
         updatePilot(wiz, accessory, device, new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
-        if (!deviceIsOffline) {
+        if (!responded) {
           onError(new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
         }
         return;
       }
-      if (deviceIsOffline) {
-        // Still offline — already responded above, nothing else to do
+      if (responded) {
+        // HomeKit already got the cached state (or the offline error)
+        wiz.log.debug(`[getPilot] No response from ${device.mac}, HomeKit was answered from cache`);
         return;
       }
-      const cached = cachedPilot[device.mac];
-      if (cached) {
-        wiz.log.warn(`[getPilot] No response from ${device.mac} within 1s, using cached state`);
-        onSuccess(cached);
-      } else {
-        onError(error);
-      }
+      // responded=false means no cache existed when the probe started (a
+      // probe success would have resolved this same coalesced batch), so
+      // there is no cached state to fall back on
+      onError(error);
       return;
     }
 
@@ -166,11 +173,11 @@ export function getPilot(
       dimming: (pilot.state ?? old?.state) ? 100 : 10,
       ...pilot
     };
-    if (cameBack) {
-      // Push fresh state to HomeKit so "No Response" clears immediately
+    if (responded) {
+      // HomeKit was answered from cache (or shown "No Response") — push the
+      // fresh state so the tile converges on reality
       updatePilot(wiz, accessory, device, pilot);
-    }
-    if (!deviceIsOffline) {
+    } else {
       onSuccess(pilot);
     }
   });

--- a/src/accessories/WizLight/pilot.ts
+++ b/src/accessories/WizLight/pilot.ts
@@ -218,14 +218,20 @@ export function setPilot(
     newPilot.speed = undefined;
   }
 
-  cachedPilot[device.mac] = {
+  const optimisticPilot = {
     ...oldPilot,
     ...newPilot,
-  } as any;
+  } as Pilot;
+  cachedPilot[device.mac] = optimisticPilot;
   const outboundPilot =
     wiz.config.lastStatus && isStateOnlyUpdate ? { state: pilot.state } : newPilot;
   return _setPilot(wiz, device, outboundPilot, (error) => {
-    if (error !== null) {
+    // Roll back only while this write still owns the cache entry. A newer
+    // queued write (or a fresh getPilot) may have replaced it by the time
+    // this write times out — the queued command is still transmitted after
+    // the failure and can succeed, so restoring this write's older snapshot
+    // would leave the cache behind the confirmed device state.
+    if (error !== null && cachedPilot[device.mac] === optimisticPilot) {
       cachedPilot[device.mac] = oldPilot;
     }
     callback(error);

--- a/src/accessories/WizSocket/pilot.ts
+++ b/src/accessories/WizSocket/pilot.ts
@@ -127,12 +127,18 @@ export function setPilot(
     sceneId: undefined,
   };
 
-  cachedPilot[device.mac] = {
+  const optimisticPilot = {
     ...oldPilot,
     ...newPilot,
-  } as any;
+  } as Pilot;
+  cachedPilot[device.mac] = optimisticPilot;
   return _setPilot(wiz, device, newPilot, (error) => {
-    if (error !== null) {
+    // Roll back only while this write still owns the cache entry. A newer
+    // queued write (or a fresh getPilot) may have replaced it by the time
+    // this write times out — the queued command is still transmitted after
+    // the failure and can succeed, so restoring this write's older snapshot
+    // would leave the cache behind the confirmed device state.
+    if (error !== null && cachedPilot[device.mac] === optimisticPilot) {
       cachedPilot[device.mac] = oldPilot;
     }
     callback(error);

--- a/src/accessories/WizSocket/pilot.ts
+++ b/src/accessories/WizSocket/pilot.ts
@@ -1,7 +1,7 @@
 import { PlatformAccessory } from "homebridge";
 
 import HomebridgeWizLan from "../../wiz";
-import { isOffline, recordFailure, recordSuccess } from "../../util/offline";
+import { isOffline, recordFailureOnce, recordSuccess } from "../../util/offline";
 import { Device } from "../../types";
 import {
   getPilot as _getPilot,
@@ -49,47 +49,56 @@ export function getPilot(
   onError: (error: Error) => void
 ) {
   const deviceIsOffline = isOffline(device.mac);
+  // Once HomeKit has been answered, the probe below only refreshes
+  // characteristics via updatePilot — the callbacks must not fire twice.
+  let responded = false;
 
   if (deviceIsOffline) {
     // Respond immediately so HomeKit doesn't wait for the UDP timeout
     onError(new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
+    responded = true;
     // Fall through to still probe the device so recovery is detected
+  } else if (typeof cachedPilot[device.mac] !== "undefined") {
+    // Answer from cache right away instead of holding HomeKit ("Updating...")
+    // through a live UDP round trip; the probe pushes fresh state when it lands
+    onSuccess(cachedPilot[device.mac]);
+    responded = true;
   }
 
   _getPilot<Pilot>(wiz, device, (error, pilot) => {
     if (error !== null) {
       const threshold = Math.max(1, Number(wiz.config.pingFailuresBeforeOffline ?? 3));
-      const newlyOffline = recordFailure(device.mac, threshold);
+      const newlyOffline = recordFailureOnce(error, device.mac, threshold);
       if (newlyOffline) {
         wiz.log.warn(`[${device.mac}] Device is now offline (${threshold} missed pings)`);
         updatePilot(wiz, accessory, device, new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
-        if (!deviceIsOffline) {
+        if (!responded) {
           onError(new wiz.api.hap.HapStatusError(wiz.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
         }
         return;
       }
-      if (deviceIsOffline) {
-        // Still offline — already responded above, nothing else to do
+      if (responded) {
+        // HomeKit already got the cached state (or the offline error)
+        wiz.log.debug(`[getPilot] No response from ${device.mac}, HomeKit was answered from cache`);
         return;
       }
-      const cached = cachedPilot[device.mac];
-      if (cached) {
-        wiz.log.warn(`[getPilot] No response from ${device.mac} within 1s, using cached state`);
-        onSuccess(cached);
-      } else {
-        onError(error);
-      }
+      // responded=false means no cache existed when the probe started (a
+      // probe success would have resolved this same coalesced batch), so
+      // there is no cached state to fall back on
+      onError(error);
       return;
     }
 
     const cameBack = recordSuccess(device.mac);
     if (cameBack) {
       wiz.log.info(`[${device.mac}] Device is back online`);
-      // Push fresh state to HomeKit so "No Response" clears immediately
-      updatePilot(wiz, accessory, device, pilot);
     }
     cachedPilot[device.mac] = pilot;
-    if (!deviceIsOffline) {
+    if (responded) {
+      // HomeKit was answered from cache (or shown "No Response") — push the
+      // fresh state so the tile converges on reality
+      updatePilot(wiz, accessory, device, pilot);
+    } else {
       onSuccess(pilot);
     }
   });

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -28,10 +28,25 @@ function getNetworkConfig({ config }: HomebridgeWizLan) {
   };
 }
 
+const GET_PILOT_TIMEOUT = 1000;
+// getPilot is an idempotent read, so retransmit it once within the timeout
+// window: a single dropped packet then costs ~400ms instead of the full
+// timeout (UDP over Wi-Fi to power-saving bulbs drops packets routinely).
+// Single retransmit only — every extra copy makes the bulb answer the same
+// probe twice, and replies carry no request id, so a duplicate landing while
+// a *later* probe is open would resolve it with stale state.
+const GET_PILOT_RETRANSMIT_DELAYS = [400];
+// setPilot acks also carry no request id (matched by source IP only), so a
+// timed-out command whose ack arrives late can be misattributed to the next
+// command in flight. 2s keeps that window to genuinely lost acks — merely
+// slow ones (1-2s) still resolve correctly — while a truly lost ack errors
+// the HomeKit callback instead of hanging it and wedging the queue forever.
+const SET_PILOT_TIMEOUT = 2000;
+
 const getPilotQueue: {
   [mac: string]: {
     callbacks: ((error: Error | null, pilot: any) => void)[];
-    timeout: NodeJS.Timeout;
+    timers: NodeJS.Timeout[];
   };
 } = {};
 export function getPilot<T>(
@@ -44,27 +59,45 @@ export function getPilot<T>(
     getPilotQueue[device.mac].callbacks.push(callback);
     return;
   }
+  const msg = `{"method":"getPilot","params":{}}`;
   // No in-flight request for this device — fire immediately
-  const timeout = setTimeout(() => {
+  const deadline = setTimeout(() => {
     if (device.mac in getPilotQueue) {
-      const { callbacks } = getPilotQueue[device.mac];
+      const { callbacks, timers } = getPilotQueue[device.mac];
+      timers.forEach(clearTimeout);
       delete getPilotQueue[device.mac];
-      callbacks.forEach((f) => f(new Error(`No response from ${device.mac} within 1s`), null as any));
+      // One shared Error instance for the whole probe — recordFailureOnce
+      // dedupes on it so one dropped packet counts as one failure, not one
+      // per coalesced callback
+      const error = new Error(`No response from ${device.mac} within 1s`);
+      callbacks.forEach((f) => f(error, null as any));
     }
-  }, 1000);
-  getPilotQueue[device.mac] = { callbacks: [callback], timeout };
+  }, GET_PILOT_TIMEOUT);
+  const retransmits = GET_PILOT_RETRANSMIT_DELAYS.map((delay) =>
+    setTimeout(() => {
+      if (device.mac in getPilotQueue) {
+        wiz.log.debug(`[getPilot] Retransmitting getPilot to ${device.mac}`);
+        // Send errors here are ignored — the deadline timer reports failure
+        wiz.socket.send(msg, BROADCAST_PORT, device.ip);
+      }
+    }, delay)
+  );
+  getPilotQueue[device.mac] = {
+    callbacks: [callback],
+    timers: [deadline, ...retransmits],
+  };
   wiz.log.debug(`[getPilot] Sending getPilot to ${device.mac}`);
   wiz.socket.send(
-    `{"method":"getPilot","params":{}}`,
+    msg,
     BROADCAST_PORT,
     device.ip,
     (error: Error | null) => {
       if (error !== null && device.mac in getPilotQueue) {
-        clearTimeout(getPilotQueue[device.mac].timeout);
+        const { callbacks, timers } = getPilotQueue[device.mac];
+        timers.forEach(clearTimeout);
         wiz.log.debug(
           `[Socket] Failed to send getPilot to ${device.mac}: ${error.toString()}`
         );
-        const { callbacks } = getPilotQueue[device.mac];
         delete getPilotQueue[device.mac];
         callbacks.forEach((f) => f(error, null as any));
       }
@@ -72,7 +105,12 @@ export function getPilot<T>(
   );
 }
 
-const setPilotQueue: { [ip: string]: ((error: Error | null) => void)[] } = {};
+const setPilotQueue: {
+  [ip: string]: {
+    callbacks: ((error: Error | null) => void)[];
+    timeout: NodeJS.Timeout;
+  };
+} = {};
 const setPilotPending: {
   [ip: string]: {
     wiz: HomebridgeWizLan;
@@ -113,14 +151,29 @@ function sendSetPilot(
     env: "pro",
     params: Object.assign({ mac: device.mac, src: "udp" }, pilot),
   });
-  setPilotQueue[device.ip] = callbacks;
+  // Without this deadline a lost ack leaves the queue entry in place forever:
+  // the HomeKit callback never resolves and every later command for this
+  // device parks in setPilotPending without ever being transmitted.
+  const timeout = setTimeout(() => {
+    if (device.ip in setPilotQueue) {
+      const { callbacks: cbs } = setPilotQueue[device.ip];
+      delete setPilotQueue[device.ip];
+      cbs.forEach((f) =>
+        f(new Error(`No setPilot response from ${device.ip} within 2s`))
+      );
+      flushPendingSetPilot(device.ip);
+    }
+  }, SET_PILOT_TIMEOUT);
+  setPilotQueue[device.ip] = { callbacks, timeout };
   wiz.log.debug(`[SetPilot][${device.ip}:${BROADCAST_PORT}] ${msg}`);
   wiz.socket.send(msg, BROADCAST_PORT, device.ip, (error: Error | null) => {
     if (error !== null && device.ip in setPilotQueue) {
       wiz.log.debug(
         `[Socket] Failed to send setPilot to ${device.ip}: ${error.toString()}`
       );
-      const cbs = setPilotQueue[device.ip];
+      const { callbacks: cbs, timeout: pendingTimeout } =
+        setPilotQueue[device.ip];
+      clearTimeout(pendingTimeout);
       delete setPilotQueue[device.ip];
       cbs.forEach((f) => f(error));
       flushPendingSetPilot(device.ip);
@@ -219,15 +272,21 @@ export function registerDiscoveryHandler(
       } else if (response.method === "getPilot") {
         const mac = response.result.mac;
         if (mac in getPilotQueue) {
-          const { callbacks, timeout } = getPilotQueue[mac];
-          clearTimeout(timeout);
+          const { callbacks, timers } = getPilotQueue[mac];
+          timers.forEach(clearTimeout);
           delete getPilotQueue[mac];
           callbacks.forEach((f) => f(null, response.result));
         }
+        // A reply landing after the deadline is dropped deliberately: crediting
+        // it (recordSuccess) would let a device with sustained >1s RTT reset
+        // the failure streak on every probe while its stale reply is discarded
+        // — never marked offline, yet cache-first would serve frozen state
+        // forever. Better that such a device truthfully goes "No Response".
       } else if (response.method === "setPilot") {
         const ip = rinfo.address;
         if (ip in setPilotQueue) {
-          const callbacks = setPilotQueue[ip];
+          const { callbacks, timeout } = setPilotQueue[ip];
+          clearTimeout(timeout);
           delete setPilotQueue[ip];
           callbacks.map((f) =>
             f(response.error ? new Error(response.error.toString()) : null)

--- a/src/util/offline.ts
+++ b/src/util/offline.ts
@@ -22,3 +22,24 @@ export function recordSuccess(mac: string): boolean {
 export function isOffline(mac: string): boolean {
   return offlineSet.has(mac);
 }
+
+type TrackedError = Error & { wizFailureRecorded?: boolean };
+
+/**
+ * Like recordFailure, but counts a shared probe error only once. All
+ * callbacks coalesced onto one in-flight UDP request receive the same Error
+ * instance, so one dropped packet must count as one failure — not one per
+ * piggybacked characteristic.
+ */
+export function recordFailureOnce(
+  error: Error,
+  mac: string,
+  threshold: number
+): boolean {
+  const tracked = error as TrackedError;
+  if (tracked.wizFailureRecorded) {
+    return false;
+  }
+  tracked.wizFailureRecorded = true;
+  return recordFailure(mac, threshold);
+}

--- a/test/accessories/WizLight/pilot.test.ts
+++ b/test/accessories/WizLight/pilot.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
   _recordSuccess(`${TEST_MAC}T1`);
   _recordSuccess(`${TEST_MAC}T2`);
   _recordSuccess(`${TEST_MAC}T3`);
-  for (const s of ["F1", "F2", "F3", "F4", "F5"]) {
+  for (const s of ["F1", "F2", "F3", "F4", "F5", "F6"]) {
     _recordSuccess(`${TEST_MAC}${s}`);
   }
 });
@@ -154,22 +154,25 @@ describe("WizLight/pilot: getPilot success path", () => {
 });
 
 describe("WizLight/pilot: error fallback & offline handling", () => {
-  it("falls back to cached state when the network errors and a cache exists", () => {
+  it("serves cached state (cache-first) and stays silent when the probe later errors under threshold", () => {
     const wiz = makeFakeWiz();
     const accessory = makeAccessoryWithService("Lightbulb");
     const device = makeDevice({ mac: `${TEST_MAC}T1` });
     cachedPilot[device.mac] = makeLightPilot({ mac: device.mac, state: true });
     let received: any = null;
+    const onError = mock((_: Error) => {});
     getPilot(
       wiz,
       accessory as any,
       device,
       (p) => (received = p),
-      () => {},
+      onError,
     );
     pendingGet[0](new Error("timeout"), null);
     expect(received).toBeDefined();
     expect(received.state).toBe(true);
+    // The probe error must not surface after HomeKit was already answered.
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("calls onError when the network errors and no cache exists", () => {
@@ -302,6 +305,77 @@ describe("WizLight/pilot: offline fast-path & recovery", () => {
     expect(err).not.toBeNull();
     expect(err.hapStatus).toBeDefined();
     expect(isOffline(mac)).toBe(true);
+  });
+});
+
+describe("WizLight/pilot: cache-first responses", () => {
+  it("answers synchronously from cache while the probe is still in flight", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeAccessoryWithService("Lightbulb");
+    const device = makeDevice({ mac: TEST_MAC });
+    cachedPilot[TEST_MAC] = makeLightPilot({ mac: TEST_MAC, dimming: 60 });
+    let received: any = null;
+    getPilot(
+      wiz,
+      accessory as any,
+      device,
+      (p) => (received = p),
+      () => {},
+    );
+    // Answered before any UDP reply was simulated...
+    expect(received).not.toBeNull();
+    expect(received.dimming).toBe(60);
+    // ...while the probe is still in flight to refresh state.
+    expect(pendingGet.length).toBe(1);
+  });
+
+  it("pushes the probe result to the characteristics after answering from cache", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeAccessoryWithService("Lightbulb");
+    const device = makeDevice({ mac: TEST_MAC });
+    cachedPilot[TEST_MAC] = makeLightPilot({
+      mac: TEST_MAC,
+      state: false,
+      dimming: 20,
+    });
+    getPilot(
+      wiz,
+      accessory as any,
+      device,
+      () => {},
+      () => {},
+    );
+    pendingGet[0](null, makeLightPilot({ mac: TEST_MAC, state: true, dimming: 42 }));
+    expect(cachedPilot[TEST_MAC].dimming).toBe(42);
+    const svc = accessory.getService(wiz.Service.Lightbulb)!;
+    expect(svc.getCharacteristic(wiz.Characteristic.On).updateValue)
+      .toHaveBeenCalled();
+    expect(svc.getCharacteristic(wiz.Characteristic.Brightness).updateValue)
+      .toHaveBeenCalled();
+  });
+
+  it("counts a shared probe error once even when several callbacks coalesced on it", () => {
+    const mac = `${TEST_MAC}F6`;
+    const wiz = makeFakeWiz({ pingFailuresBeforeOffline: 2 } as any);
+    const accessory = makeAccessoryWithService("Lightbulb");
+    const device = makeDevice({ mac });
+    // Two HomeKit GETs coalesce onto one UDP probe; on timeout the network
+    // layer hands the SAME Error instance to both callbacks.
+    getPilot(wiz, accessory as any, device, () => {}, () => {});
+    getPilot(wiz, accessory as any, device, () => {}, () => {});
+    const shared = new Error("timeout");
+    pendingGet[0](shared, null);
+    pendingGet[1](shared, null);
+    // One dropped packet = one failure, so threshold 2 is NOT crossed.
+    expect(isOffline(mac)).toBe(false);
+
+    // A second dropped probe (fresh Error) is a genuine second failure.
+    pendingGet.length = 0;
+    let err: any = null;
+    getPilot(wiz, accessory as any, device, () => {}, (e) => (err = e));
+    pendingGet[0](new Error("timeout"), null);
+    expect(isOffline(mac)).toBe(true);
+    expect(err.hapStatus).toBeDefined();
   });
 });
 

--- a/test/accessories/WizLight/pilot.test.ts
+++ b/test/accessories/WizLight/pilot.test.ts
@@ -477,6 +477,27 @@ describe("WizLight/pilot: setPilot scene/color exclusivity", () => {
     pendingSet[0](new Error("boom"));
     expect(cachedPilot[TEST_MAC]).toBe(oldPilot);
   });
+
+  it("does not revert the cache when a newer write replaced it before the failure", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeAccessoryWithService("Lightbulb");
+    cachedPilot[TEST_MAC] = makeLightPilot({
+      mac: TEST_MAC,
+      state: false,
+      dimming: 20,
+    });
+    setPilot(wiz, accessory as any, baseDevice, { state: true }, () => {});
+    setPilot(wiz, accessory as any, baseDevice, { dimming: 80 }, () => {});
+    // The second write owns the cache now; the first write's failure must not
+    // restore the snapshot that predates both writes.
+    pendingSet[0](new Error("ack timeout"));
+    expect(cachedPilot[TEST_MAC].state).toBe(true);
+    expect(cachedPilot[TEST_MAC].dimming).toBe(80);
+    // The second write succeeding leaves its own optimistic state in place.
+    pendingSet[1](null);
+    expect(cachedPilot[TEST_MAC].state).toBe(true);
+    expect(cachedPilot[TEST_MAC].dimming).toBe(80);
+  });
 });
 
 describe("WizLight/pilot: updateColorTemp", () => {

--- a/test/accessories/WizSocket/pilot.test.ts
+++ b/test/accessories/WizSocket/pilot.test.ts
@@ -73,21 +73,24 @@ describe("WizSocket/pilot: getPilot", () => {
     expect(cachedPilot[TEST_MAC].state).toBe(true);
   });
 
-  it("falls back to cached state when the network errors and a cache exists", () => {
+  it("serves cached state (cache-first) and stays silent when the probe later errors under threshold", () => {
     const wiz = makeFakeWiz();
     const accessory = makeOutletAccessory();
     const device = makeDevice({ mac: `${TEST_MAC}_T1`, model: "ESP10_SOCKET_06" });
     cachedPilot[device.mac] = makeSocketPilot({ mac: device.mac, state: true });
     let received: any = null;
+    const onError = mock((_: Error) => {});
     getPilot(
       wiz,
       accessory as any,
       device,
       (p) => (received = p),
-      () => {},
+      onError,
     );
     pendingGet[0](new Error("timeout"), null);
     expect(received?.state).toBe(true);
+    // The probe error must not surface after HomeKit was already answered.
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("calls onError when the network errors and no cache exists", () => {
@@ -104,6 +107,44 @@ describe("WizSocket/pilot: getPilot", () => {
     );
     pendingGet[0](new Error("timeout"), null);
     expect(err).not.toBeNull();
+  });
+});
+
+describe("WizSocket/pilot: cache-first responses", () => {
+  it("answers synchronously from cache while the probe is still in flight", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeOutletAccessory();
+    const device = makeDevice({ mac: TEST_MAC, model: "ESP10_SOCKET_06" });
+    cachedPilot[TEST_MAC] = makeSocketPilot({ mac: TEST_MAC, state: true });
+    let received: any = null;
+    getPilot(
+      wiz,
+      accessory as any,
+      device,
+      (p) => (received = p),
+      () => {},
+    );
+    expect(received?.state).toBe(true);
+    expect(pendingGet.length).toBe(1);
+  });
+
+  it("pushes the probe result to the Outlet characteristic after answering from cache", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeOutletAccessory();
+    const device = makeDevice({ mac: TEST_MAC, model: "ESP10_SOCKET_06" });
+    cachedPilot[TEST_MAC] = makeSocketPilot({ mac: TEST_MAC, state: false });
+    getPilot(
+      wiz,
+      accessory as any,
+      device,
+      () => {},
+      () => {},
+    );
+    pendingGet[0](null, makeSocketPilot({ mac: TEST_MAC, state: true }));
+    expect(cachedPilot[TEST_MAC].state).toBe(true);
+    const svc = accessory.getService(wiz.Service.Outlet)!;
+    expect(svc.getCharacteristic(wiz.Characteristic.On).updateValue)
+      .toHaveBeenCalled();
   });
 });
 

--- a/test/accessories/WizSocket/pilot.test.ts
+++ b/test/accessories/WizSocket/pilot.test.ts
@@ -274,4 +274,19 @@ describe("WizSocket/pilot: setPilot", () => {
     pendingSet[0](new Error("oops"));
     expect(cachedPilot[TEST_MAC]).toBe(oldPilot);
   });
+
+  it("does not revert the cache when a newer write replaced it before the failure", () => {
+    const wiz = makeFakeWiz();
+    const accessory = makeOutletAccessory();
+    const device = makeDevice({ mac: TEST_MAC, model: "ESP10_SOCKET_06" });
+    cachedPilot[TEST_MAC] = makeSocketPilot({ mac: TEST_MAC, state: false });
+    setPilot(wiz, accessory as any, device, { state: true }, () => {});
+    setPilot(wiz, accessory as any, device, { state: true }, () => {});
+    // The second write owns the cache now; the first write's failure must not
+    // restore the snapshot that predates both writes.
+    pendingSet[0](new Error("ack timeout"));
+    expect(cachedPilot[TEST_MAC].state).toBe(true);
+    pendingSet[1](null);
+    expect(cachedPilot[TEST_MAC].state).toBe(true);
+  });
 });

--- a/test/util/network.test.ts
+++ b/test/util/network.test.ts
@@ -13,9 +13,15 @@ import {
   setPilot,
 } from "../../src/util/network";
 import {
+  cachedPilot,
+  setPilot as setLightPilot,
+} from "../../src/accessories/WizLight/pilot";
+import {
   FakeSocket,
+  makeAccessoryWithService,
   makeDevice,
   makeFakeWiz,
+  makeLightPilot,
 } from "../__helpers__/factories";
 
 // The util/network module keeps per-mac/per-ip callback queues at module
@@ -212,6 +218,62 @@ describe("network: setPilot ack timeout", () => {
       { address: device.ip, port: 38899 },
     );
     expect(errB).toBeNull();
+  }, 10000);
+
+  it("preserves a newer queued write when the preceding ack times out", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    registerDiscoveryHandler(wiz, () => {});
+    const device = uniqueDevice({ ip: "10.7.7.10" });
+    const accessory = makeAccessoryWithService("Lightbulb");
+    cachedPilot[device.mac] = makeLightPilot({
+      mac: device.mac,
+      state: false,
+      dimming: 20,
+    });
+
+    let firstError: Error | null | undefined;
+    let secondError: Error | null | undefined;
+    setLightPilot(
+      wiz,
+      accessory as any,
+      device,
+      { state: true },
+      (error) => (firstError = error),
+    );
+    setLightPilot(
+      wiz,
+      accessory as any,
+      device,
+      { dimming: 80 },
+      (error) => (secondError = error),
+    );
+
+    expect(cachedPilot[device.mac].state).toBe(true);
+    expect(cachedPilot[device.mac].dimming).toBe(80);
+
+    await new Promise((resolve) => setTimeout(resolve, 2150));
+    expect(firstError).toBeInstanceOf(Error);
+
+    const sends = (wiz.socket as FakeSocket).sent.filter((sent) =>
+      sent.msg.includes('"setPilot"'),
+    );
+    expect(sends).toHaveLength(2);
+    expect(JSON.parse(sends[1].msg).params).toMatchObject({
+      state: true,
+      dimming: 80,
+    });
+
+    wiz.socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ method: "setPilot", result: {} })),
+      { address: device.ip, port: 38899 },
+    );
+    expect(secondError).toBeNull();
+
+    // B was sent and acknowledged, so A's timeout must not restore the cache
+    // snapshot that predates both writes.
+    expect(cachedPilot[device.mac].state).toBe(true);
+    expect(cachedPilot[device.mac].dimming).toBe(80);
   }, 10000);
 
   it("an ack clears the deadline, so a later command is not errored by the earlier command's stale timer", async () => {

--- a/test/util/network.test.ts
+++ b/test/util/network.test.ts
@@ -82,6 +82,48 @@ describe("network: getPilot in-flight dedup", () => {
     expect(errors[0]).not.toBeNull();
     expect(errors[1]).not.toBeNull();
     expect(errors[0]!.message).toMatch(/No response/);
+    // All coalesced callbacks must receive the SAME Error instance — the
+    // accessory layer dedupes offline-failure counting on it, so one dropped
+    // packet counts as one failure rather than one per characteristic.
+    expect(errors[0]).toBe(errors[1]!);
+  }, 5000);
+});
+
+describe("network: getPilot retransmits", () => {
+  it("retransmits the request once while unanswered (2 packets inside the 1s window)", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    const device = uniqueDevice();
+    getPilot(wiz, device, () => {});
+    // The retransmit fires at 400ms; sample well past it but before the 1s
+    // deadline.
+    await new Promise((r) => setTimeout(r, 750));
+    const sends = (wiz.socket as FakeSocket).sent.filter((s) =>
+      s.msg.includes('"getPilot"'),
+    );
+    expect(sends.length).toBe(2);
+    expect(sends.every((s) => s.ip === device.ip)).toBe(true);
+  }, 5000);
+
+  it("stops retransmitting once a reply arrives", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    registerDiscoveryHandler(wiz, () => {});
+    const device = uniqueDevice();
+    getPilot(wiz, device, () => {});
+    wiz.socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          method: "getPilot",
+          result: { mac: device.mac, state: true },
+        }),
+      ),
+      { address: device.ip, port: 38899 },
+    );
+    await new Promise((r) => setTimeout(r, 800));
+    expect(
+      (wiz.socket as FakeSocket).sent.filter((s) => s.msg.includes('"getPilot"'))
+        .length,
+    ).toBe(1);
   }, 5000);
 });
 
@@ -119,6 +161,127 @@ describe("network: setPilot payload composition", () => {
     // First one fires; rest stay in setPilotPending until the first completes
     expect(sends.length).toBe(1);
   });
+});
+
+describe("network: setPilot ack timeout", () => {
+  it("errors the callback and frees the queue when the ack never arrives", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    const device = uniqueDevice({ ip: "10.7.7.1" });
+    let err: Error | null | undefined = undefined;
+    setPilot(wiz, device, { state: true } as any, (e) => (err = e));
+    await new Promise((r) => setTimeout(r, 2150));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as unknown as Error).message).toMatch(/No setPilot response/);
+    // The queue must be freed: a new command goes out immediately instead of
+    // being parked behind the dead entry.
+    setPilot(wiz, device, { state: false } as any, () => {});
+    const sends = (wiz.socket as FakeSocket).sent.filter((s) =>
+      s.msg.includes('"setPilot"'),
+    );
+    expect(sends.length).toBe(2);
+  }, 10000);
+
+  it("a command queued behind a lost ack is transmitted after the timeout instead of being parked forever", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    registerDiscoveryHandler(wiz, () => {});
+    const device = uniqueDevice({ ip: "10.7.7.2" });
+    let errA: Error | null | undefined = undefined;
+    let errB: Error | null | undefined = undefined;
+    setPilot(wiz, device, { state: true } as any, (e) => (errA = e));
+    setPilot(wiz, device, { dimming: 42 } as any, (e) => (errB = e));
+    // Only the first command is on the wire; the second is pending.
+    expect(
+      (wiz.socket as FakeSocket).sent.filter((s) => s.msg.includes('"setPilot"'))
+        .length,
+    ).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 2150));
+    // First command timed out...
+    expect(errA).toBeInstanceOf(Error);
+    // ...and the pending command was flushed onto the wire.
+    const sends = (wiz.socket as FakeSocket).sent.filter((s) =>
+      s.msg.includes('"setPilot"'),
+    );
+    expect(sends.length).toBe(2);
+    expect(JSON.parse(sends[1].msg).params.dimming).toBe(42);
+
+    // Its ack resolves its callback normally.
+    wiz.socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ method: "setPilot", result: {} })),
+      { address: device.ip, port: 38899 },
+    );
+    expect(errB).toBeNull();
+  }, 10000);
+
+  it("an ack clears the deadline, so a later command is not errored by the earlier command's stale timer", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    registerDiscoveryHandler(wiz, () => {});
+    const device = uniqueDevice({ ip: "10.7.7.3" });
+    const ack = () =>
+      wiz.socket.emit(
+        "message",
+        Buffer.from(JSON.stringify({ method: "setPilot", result: {} })),
+        { address: device.ip, port: 38899 },
+      );
+
+    let errA: Error | null | undefined = undefined;
+    let errB: Error | null | undefined = undefined;
+    setPilot(wiz, device, { state: true } as any, (e) => (errA = e));
+    ack();
+    expect(errA).toBeNull();
+
+    // Send B well after A so their deadlines don't overlap: A's stale timer
+    // (had it leaked) would fire at t=2000ms, before B's own at t=2700ms.
+    await new Promise((r) => setTimeout(r, 700));
+    setPilot(wiz, device, { state: false } as any, (e) => (errB = e));
+    await new Promise((r) => setTimeout(r, 1550)); // t≈2250ms
+    expect(errB).toBeUndefined();
+    ack();
+    expect(errB).toBeNull();
+  }, 10000);
+
+  it("a send error clears the deadline, so a later command is not errored by the stale timer", async () => {
+    const wiz = makeFakeWiz(baseConfig());
+    registerDiscoveryHandler(wiz, () => {});
+    const device = uniqueDevice({ ip: "10.7.7.4" });
+    const sock = wiz.socket as FakeSocket;
+    // Fail exactly one send at the socket level.
+    let failNext = true;
+    const realSend = sock.send;
+    (sock as any).send = (
+      msg: string | Buffer,
+      port: number,
+      ip: string,
+      cb?: (err: Error | null) => void,
+    ) => {
+      if (failNext) {
+        failNext = false;
+        sock.sent.push({ msg: msg.toString(), port, ip });
+        cb?.(new Error("EHOSTUNREACH"));
+        return;
+      }
+      realSend(msg, port, ip, cb);
+    };
+
+    let errA: Error | null | undefined = undefined;
+    let errB: Error | null | undefined = undefined;
+    setPilot(wiz, device, { state: true } as any, (e) => (errA = e));
+    expect(errA).toBeInstanceOf(Error);
+
+    // A's stale timer (had it leaked) would fire at t=2000ms, before B's own
+    // deadline at t=2700ms.
+    await new Promise((r) => setTimeout(r, 700));
+    setPilot(wiz, device, { state: false } as any, (e) => (errB = e));
+    await new Promise((r) => setTimeout(r, 1550)); // t≈2250ms
+    expect(errB).toBeUndefined();
+    wiz.socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ method: "setPilot", result: {} })),
+      { address: device.ip, port: 38899 },
+    );
+    expect(errB).toBeNull();
+  }, 10000);
 });
 
 describe("network: discovery message routing", () => {


### PR DESCRIPTION
## Problem

Tapping a light in the Home app sometimes shows **"Updating…"** for a long time before the tile settles, and the requested action executes late — or never, until Homebridge restarts. The root causes are all in how the UDP transport handles routine packet loss (WiZ bulbs sit in Wi-Fi power-save and drop/delay UDP regularly).

## Root causes and fixes

**1. `setPilot` had no ack timeout — one lost ack wedged the device's command queue permanently** (`src/util/network.ts`)
The per-IP queue entry was only cleared by a received ack or a local send error. A lost ack left the HomeKit SET callback hanging (spinner until HAP gives up ~10s) and parked every subsequent command in `setPilotPending` *without ever transmitting it*, until restart. There is now a 2s deadline that errors the callbacks, frees the queue, and flushes the pending command. 2s rather than 1s because acks carry no request id (matched by source IP only), so a longer window keeps merely-slow acks attributed to the right command.

**2. `getPilot` was single-shot: one packet, 1s deadline, no retry**
Any dropped packet cost the full visible second. It now retransmits once at 400ms inside the unchanged 1s deadline. Deliberately a single copy: replies also carry no request id, and extra duplicates could resolve a *later* probe with stale state.

**3. Every characteristic GET blocked on a live UDP round trip**
GETs now answer HomeKit synchronously from `cachedPilot` when a cache exists, while the probe still runs and pushes fresh state to the characteristics (`updatePilot`) when it lands. Tiles render instantly and converge instead of spinning.

**4. One dropped reply counted as 5–7 failures**
All characteristic GETs from one tile-open coalesce onto a single UDP probe, but on timeout each coalesced callback independently incremented the offline failure counter — one lost packet blew straight past the `pingFailuresBeforeOffline` threshold of 3 and flapped the device to "No Response". The deadline now hands every coalesced callback the *same* `Error` instance and `recordFailureOnce` dedupes on it, so one lost packet counts once.

## Notes on tradeoffs (documented in code comments)

- A reply arriving after the 1s deadline is still dropped without crediting the device: crediting it would let a sustained-slow (>1s RTT) device reset its failure streak forever while cache-first serves frozen state — never offline, never fresh. Such a device should truthfully go "No Response".
- Ack/reply correlation is by IP/MAC only (the WiZ protocol offers no echoed request id here), so a >2s-late ack can still, in principle, be attributed to the next in-flight command; the 2s window plus absolute-state commands make this self-healing.

## Tests

- 159 tests pass (10 new), coverage 87.8% lines / 75.7% funcs (floors: 85 / 70), `tsc` build clean.
- New tests pin: the lost-ack unwedge + pending flush, ack-timeout error, stale-deadline clearing on both the ack path and the send-error path (with an erroring socket), single retransmit + stop-on-reply, shared-Error-instance delivery to coalesced callbacks, cache-first synchronous answers, post-probe characteristic push, and once-per-probe failure counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLcRtL7eBTbe7S3bLzY96)_